### PR TITLE
add project and module to nav xref

### DIFF
--- a/docs/modules/ROOT/partials/nav-explanation.adoc
+++ b/docs/modules/ROOT/partials/nav-explanation.adoc
@@ -1,8 +1,8 @@
 * System
-** xref:explanation/system/context.adoc[System context]
-** xref:explanation/system/idea.adoc[System idea]
+** xref:appuio-pubic:ROOT:explanation/system/context.adoc[System context]
+** xref:appuio-pubic:ROOT:explanation/system/idea.adoc[System idea]
 
 * Decisions
-** xref:explanation/decisions/keycloak.adoc[Keycloak as IDP]
-** xref:explanation/decisions/kyverno-policy.adoc[Kyverno as policy engine]
-** xref:explanation/decisions/kyverno-generator.adoc[Keyverno as resource generator]
+** xref:appuio-pubic:ROOT:explanation/decisions/keycloak.adoc[Keycloak as IDP]
+** xref:appuio-pubic:ROOT:explanation/decisions/kyverno-policy.adoc[Kyverno as policy engine]
+** xref:appuio-pubic:ROOT:explanation/decisions/kyverno-generator.adoc[Keyverno as resource generator]

--- a/docs/modules/ROOT/partials/nav-reference.adoc
+++ b/docs/modules/ROOT/partials/nav-reference.adoc
@@ -1,1 +1,1 @@
-* xref:references/glossary.adoc[Glossary]
+* xref:appuio-public:ROOT:references/glossary.adoc[Glossary]


### PR DESCRIPTION
the navigation links work on https://kb.vshn.ch/appuio-public/index.html but not on https://kb.vshn.ch/kb/index.html, I suspect because the project and module are missing from the xref compared with https://raw.githubusercontent.com/vshn/public-cloud-docs/master/docs/modules/ROOT/partials/nav-howtos.adoc