### PR TITLE
Prevent region zone confusion

### DIFF
--- a/docs/modules/ROOT/pages/references/glossary.adoc
+++ b/docs/modules/ROOT/pages/references/glossary.adoc
@@ -25,7 +25,7 @@ Namespace::
 A Kubernetes namespace (in OpenShift also an object type "Project")
 
 Zone::
-A single OpenShift cluster that is part of an APPUiO public offering in a particular cloud-providers zone.
+A single OpenShift cluster that is part of an APPUiO public offering.
 
 
 Admin::


### PR DESCRIPTION
Usually, a cluster gets placed within a cloud providers region and gets
spread across the zones within that region for resiliency.