### PR TITLE
Add how-to page to configure Keycloak brokering

### DIFF
--- a/docs/modules/ROOT/assets/images/how-to/keycloak-brokering.drawio.svg
+++ b/docs/modules/ROOT/assets/images/how-to/keycloak-brokering.drawio.svg
@@ -1,0 +1,140 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="601px" height="221px" viewBox="-0.5 -0.5 601 221" content="&lt;mxfile host=&quot;embed.diagrams.net&quot; modified=&quot;2021-09-06T12:09:42.839Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.59.0 Chrome/91.0.4472.124 Electron/13.1.7 Safari/537.36&quot; etag=&quot;XvAwZvNM9NWdCA6Ab8dm&quot; version=&quot;15.0.6&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;6su2di-Jg9wwhpTBm6wG&quot; name=&quot;Page-1&quot;&gt;7VjbjtowEP0aHkG5Fx6Xy26lUhUJVd32zZAhcTdkkDGX7NfXJmNCSKiQFihIfVl5jj0Te87JcdiG25tvXwRbxF8xhKThWOG24fYbjhN02uqvBrIc8G0rByLBwxyyC2DM34FAs2zFQ1iWFkrERPJFGZximsJUljAmBG7Ky2aYlJ+6YBFUgPGUJVX0Bw9lnKNt3yrwz8Cj2DzZtmhmzsxiApYxC3FzALmDhtsTiDIfzbc9SHTvTF/yvOcTs/uNCUjlWQmUsZSZORyE6qwUopAxRpiyZFCgXYGrNARdwVJRsWaIuFCgrcDfIGVGxLGVRAXFcp7QLGy5fKV0Pf6pxy2fov72YKqfmSCVIns1BXRwkKXDIm0XmbxqR8yRcSWmdGaHRMREBLQqyCHdjYM06uIL4BzUU9QCAQmTfF1WBiOBRft1BQdqQDScoIQ2s2bJiqpOBL6BUB13gkRtrzsRahTp0RAjntZSOGQT9dKV2s4SHqVqPFWtAKGANQjJlayfaGLOwzBnGJb8nU129XQTF8hTuTuT3234/fq20tl1UdjWvYdUsCT1Ui8py2o5nuflqeQQTap0drep+EhvvKhsDCSrzcfZbKnoP+Zqv8Gz6Kuy9zQafeffFPYFsmmC7K3CV/FCaZo2MZcwXrCdODfKQMssnhR0pfEnG+x0jvrwieJN4Wa2cbP40MmMb31E4O3/lqNCt2o5zr+yHPe0Zn9hCn/Rq3UTvfrekV6dGr06NXoNLiDXzqPI9SzZeZfWWL3RekeMOe4RE7nuKetDhmtX1XtHt2LnUpdi02oFlt25xq3Y9MtkNTtXuBe9B/MYx7qhx5jvkvs3maveif4d3Yn+o+m1fUO9BpXmPKMAbZd39JUb3PAjV4XFj/bcHYv/fLiDPw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 230 110 L 156.37 110" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 151.12 110 L 158.12 106.5 L 156.37 110 L 158.12 113.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 110px; margin-left: 191px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                brokered
+                                <br/>
+                                Login
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="191" y="114" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    brokered...
+                </text>
+            </switch>
+        </g>
+        <rect x="230" y="50" width="150" height="120" rx="18" ry="18" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 110px; margin-left: 231px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                APPUiO Keycloak
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="305" y="114" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    APPUiO Keycloak
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 30 L 430 30 L 430 110 L 386.37 110" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 381.12 110 L 388.12 106.5 L 386.37 110 L 388.12 113.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="0" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 30px; margin-left: 481px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                APPUiO Zone
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="540" y="34" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    APPUiO Zone
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 110 L 386.37 110" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 381.12 110 L 388.12 106.5 L 386.37 110 L 388.12 113.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 100px; margin-left: 410px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                Login
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="410" y="104" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Login
+                </text>
+            </switch>
+        </g>
+        <rect x="480" y="80" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 110px; margin-left: 481px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                APPUiO Zone
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="540" y="114" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    APPUiO Zone
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 190 L 430 190 L 430 110 L 386.37 110" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 381.12 110 L 388.12 106.5 L 386.37 110 L 388.12 113.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="480" y="160" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 190px; margin-left: 481px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                APPUiO Zone
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="540" y="194" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    APPUiO Zone
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="50" width="150" height="120" rx="18" ry="18" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 110px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Foreign Keycloak
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="114" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Foreign Keycloak
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/modules/ROOT/pages/how-to/keycloak-brokering.adoc
+++ b/docs/modules/ROOT/pages/how-to/keycloak-brokering.adoc
@@ -1,0 +1,82 @@
+= Add another Keycloak for brokering
+:appuio-keycloak: id.dev.appuio.cloud
+:appuio-realm: appuio-public
+:foreign-idp-alias: foreign-idp
+:foreign-host: foreign.hostname.tld
+:foreign-realm: foreign-realm
+:foreign-client-id: appuio-cloud-id
+
+This guide describes the steps required to configure the APPUiO Keycloak so that a foreign Keycloak as Identity Providers can be used.
+
+NOTE: This page is meant to be growing and doesn't contain the final configuration at this time.
+
+image:how-to/keycloak-brokering.drawio.svg[]
+
+== Prerequisites
+
+* Installed APPUiO Keycloak (see xref:appuio-cloud:ROOT:how-to/keycloak-setup.adoc[Install Keycloak])
+* Administrator console access to APPUiO Keycloak
+* Administrator console access to foreign Keycloak
+
+TIP: It's easiest to configure brokering if you have both administration console ready in 2 browser tabs next to eachother.
+
+For the purpose of this guide, we will use the following names, interchange them as needed:
+
+|===
+| Key | Description
+
+| `{appuio-keycloak}`
+| APPUiO Keycloak hostname
+
+| `{foreign-host}`
+| Foreign Keycloak hostname
+
+| `{appuio-realm}`
+| Realm within `{appuio-keycloak}` (currently still `public`, not yet renamed to `cloud`)
+
+| `{foreign-realm}`
+| Realm within `{foreign-host}`
+
+| `{foreign-idp-alias}`
+| The Alias given to `{foreign-host}`
+
+| `{foreign-client-id}`
+| The Client ID for `{appuio-keycloak}` within `{foreign-host}`
+
+|===
+
+== Add new Client to foreign Keycloak
+
+. Log in as administrator to admin console in the **foreign Keycloak instance** and select the desired realm.
+. Add a new Client and configure the following settings:
++
+[source,subs="attributes+"]
+----
+Client ID = {foreign-client-id}
+Access Type = confidential
+Direct Access Grants Enabled = True
+Valid Redict URIs = https://{appuio-keycloak}/auth/realms/{appuio-realm}/broker/{foreign-idp-alias}/endpoint
+----
+
+. After saving, go into edit mode again and select the "Credentials" tab.
+. Keep the displayed Secret ready for copy-pasting.
+
+== Configure Identity Provider
+
+. Log in as administrator to admin console in the **APPUiO Keycloak instance** and select the desired realm.
+. Add a new Identity Provider (select `Keycloak OpenID Connect`) and configure the following settings:
++
+[source,subs="attributes+"]
+----
+Alias = {foreign-idp-alias}
+Display Name = A human friendly name displayed in the Login page
+Trust Email = True
+Sync Mode = force
+Authorization URL = https://{foreign-host}/auth/realms/{foreign-realm}/protocol/openid-connect/auth
+Token URL = https://{foreign-host}/auth/realms/{foreign-realm}/protocol/openid-connect/token
+Logout URL = https://{foreign-host}/auth/realms/{foreign-realm}/protocol/openid-connect/logout
+User Info URL = https://{foreign-host}/auth/realms/{foreign-realm}/protocol/openid-connect/userinfo
+Client Authentication = "Client secret sent as post"
+Client ID = {foreign-client-id}
+Client Secret = <The secret displayed in {appuio-keycloak} Credentials tab>
+----

--- a/docs/modules/ROOT/pages/how-to/keycloak-setup.adoc
+++ b/docs/modules/ROOT/pages/how-to/keycloak-setup.adoc
@@ -1,4 +1,4 @@
-= Install Keycloak on APPUiO Zone
+= Install Keycloak on {zone}
 
 This guide describes the steps required to install the APPUiO IDP onto one of the APPUiO Zones (clusters).
 

--- a/docs/modules/ROOT/partials/nav-howtos.adoc
+++ b/docs/modules/ROOT/partials/nav-howtos.adoc
@@ -1,2 +1,3 @@
 * Installation
 ** xref:appuio-cloud:ROOT:how-to/keycloak-setup.adoc[Install Keycloak]
+** xref:appuio-cloud:ROOT:how-to/keycloak-brokering.adoc[Add Keycloak brokering]


### PR DESCRIPTION
# Summary

* Adds installation page to configure Keycloak-to-Keycloak brokering (base configuration so that login works)
* The brokering works so that when Appuio Keycloak displays the login form, there's the option that says "...or sign in with `other Keycloak`"

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
