### PR TITLE
Reformat decision documents

### DIFF
--- a/docs/modules/ROOT/pages/explanation/decisions/arbitrary-usernames.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/arbitrary-usernames.adoc
@@ -1,24 +1,28 @@
 = User name choice on sign-up
 
-Problem::
+== Problem
+
 Users need a user name (unique identifier) in {product}.
-+
+
 This identifier should have the following properties:
 
 * It should be stable for the lifetime of the user in Keycloak.
 * Users should be able to xref:references/quality-requirements/usability/user-arbitrary-name.adoc[choose it freely].
 
-Alternatives::
-* Use the user's email address as their unique identifier.
-* Let users choose an arbitrary user name.
-* Generate a unique identifier (for example `u-blue-sound-7239`) when the user signs up.
+== Alternatives
 
-Decision::
-We allow users to freely choose their user name when signing up
+. Use the user's email address as their unique identifier.
+. Let users choose an arbitrary user name.
+. Generate a unique identifier (for example `u-blue-sound-7239`) when the user signs up.
 
-Rationale::
+== Decision
+
+Let users choose an arbitrary user name.
+
+== Rationale
+
 Allowing users to freely choose their user name when signing up increases user experience since they can choose a memorable name they like.
-+
+
 Using the user's email address as their unique identifier becomes problematic quickly, as a user's email address may change at any time.
-+
+
 A generated identifier would be an elegant solution from a technical perspective, but generated names are usually not very memorable.

--- a/docs/modules/ROOT/pages/explanation/decisions/keycloak.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/keycloak.adoc
@@ -1,27 +1,32 @@
 = Keycloak as IDP
 
-Problem::
+== Problem
+
 We need to store user (including passwords), team memberships and organizations.
 
 //Relevant requirements::
 //* tbd, links to requirement page(s)
 
-Alternatives::
-* LDAP via control.vshn.net.
-  We can use the existing infrastructure to manage users and organizations.
+== Alternatives
 
-* VSHN-owned Keycloak.
-  There is id.vshn.net which we could integrate {product} customers.
+[qanda]
+LDAP via control.vshn.net::
+We can use the existing infrastructure to manage users and organizations.
 
-* APPUiO-owned Keycloak.
-  Each APPUiO instance brings its own Keycloak.
-  This still leaves doors open for federation scenarios or other social logins like GitHub or Google.
+VSHN-owned Keycloak::
+There is id.vshn.net which we could integrate {product} customers.
 
-Decision::
+APPUiO-owned Keycloak::
+Each APPUiO instance brings its own Keycloak.
+This still leaves doors open for federation scenarios or other social logins like GitHub or Google.
+
+== Decision
+
 APPUiO-owned Keycloak
 
-Rationale::
+== Rationale
+
 Keycloak is a well-known Identity Provider that provides SSO.
 To ease integrations between zones, each APPUiO instance brings its own managed Keycloak.
-+
+
 There are also plans to make {product} resellable, meaning that nothing should really depend on VSHN infrastructure.

--- a/docs/modules/ROOT/pages/explanation/decisions/kyverno-generator.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/kyverno-generator.adoc
@@ -1,6 +1,7 @@
 = Kyverno as resource generator
 
-Problem::
+== Problem
+
 Each APPUiO namespace requires user-immutable resources, such as `ResourceQuota` or `LimitRanges`.
 A solution is needed that creates and maintains such resources immediately upon creating Namespaces.
 All generated resources are generally the same, but the solution must be able to deviate from the default for selected Namespaces.
@@ -8,26 +9,31 @@ All generated resources are generally the same, but the solution must be able to
 //Relevant requirements::
 //* tbd, links to requirement page(s)
 
-Relevant decisions::
+== Relevant decisions
+
 * xref:explanation/decisions/kyverno-policy.adoc[Kyverno as policy engine]
 
-Alternatives::
-* APPUiO Operator.
-  A custom controller or operator that watches Namespaces resources and generates resources from a template.
+== Alternatives
 
-* https://github.com/vshn/espejo[Espejo].
-  An operator designed to generate resources in every selected Namespace.
-  The feature for deviating from defaults resp. the cleanup after changing the default must yet be implemented.
+[qanda]
+APPUiO Operator::
+A custom controller or operator that watches Namespaces resources and generates resources from a template.
 
-* https://kyverno.io/[Kyverno].
-  Kyverno is a Kubernetes native policy engine that uses Kyverno-specific CRDs to configure policies.
-  It also supports "generating" policies, e.g. depending on configurable conditions, arbitrary resources can be created.
+https://github.com/vshn/espejo[Espejo]::
+An operator designed to generate resources in every selected Namespace.
+The feature for deviating from defaults resp. the cleanup after changing the default must yet be implemented.
 
-Decision::
+https://kyverno.io/[Kyverno]::
+Kyverno is a Kubernetes native policy engine that uses Kyverno-specific CRDs to configure policies.
+It also supports "generating" policies, e.g. depending on configurable conditions, arbitrary resources can be created.
+
+== Decision
+
 Kyverno
 
-Rationale::
+== Rationale
+
 Both Espejo and a potential APPUiO operator need programming effort for features that don't yet exist.
 Kyverno supports the given use case already, thus writing such generator policies is considered to be a lower effort.
-+
+
 NOTE: Choosing Kyverno as policy engine and resource generator reduces complexity.

--- a/docs/modules/ROOT/pages/explanation/decisions/kyverno-policy.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/kyverno-policy.adoc
@@ -1,30 +1,37 @@
 = Kyverno as policy engine
 
-Problem::
+== Problem
+
 Kubernetes RBAC rules are not suitable to validate certain properties of resources.
 They can only allow or deny operations of the whole resource.
 On {product} however, we require fine-grained control of certain properties, such as labels or annotations on Namespaces.
 
-Relevant requirements::
+== Relevant requirements
+
 * xref:references/quality-requirements/reliability/ns-validation-resilience.adoc[Namespace validation resilience]
 * xref:references/quality-requirements/usability/ns-arbitrary-name.adoc[Arbitrary Namespace name]
 
-Relevant decisions::
+== Relevant decisions
+
 * xref:explanation/decisions/kyverno-generator.adoc[Kyverno as resource generator]
 
-Alternatives::
-* https://www.openpolicyagent.org/[OPA].
-  Open Policy Agent is a policy engine written for cloud native environments.
-  Policies are written in Rego, which is declarative query language suited for writing policies.
+== Alternatives
 
-* https://kyverno.io/[Kyverno].
-  Kyverno is a Kubernetes native policy engine that uses Kyverno-specific CRDs to configure policies.
+[qanda]
+https://www.openpolicyagent.org/[OPA]::
+Open Policy Agent is a policy engine written for cloud native environments.
+Policies are written in Rego, which is declarative query language suited for writing policies.
 
-Decision::
+https://kyverno.io/[Kyverno]::
+Kyverno is a Kubernetes native policy engine that uses Kyverno-specific CRDs to configure policies.
+
+== Decision
+
 Kyverno
 
-Rationale::
+== Rationale
+
 Kyverno doesn't require learning a declarative language compared to OPA.
 Especially writing mutating policies is subjectively easier in Kyverno than with OPA/Rego.
-+
+
 NOTE: Choosing Kyverno as policy engine and resource generator reduces complexity.

--- a/docs/modules/ROOT/pages/explanation/decisions/stable-usernames.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/stable-usernames.adoc
@@ -1,20 +1,24 @@
 = User name stability
 
-Problem::
+== Problem
+
 In the decision regarding xref:explanation/decisions/usernames.adoc[`User` object names in the OpenShift cluster], we chose to use the user's Keycloak `Username` property as the identifier for the user in the OpenShift cluster.
-+
+
 Due to some technical limitations in OpenShift, this choice requires that the user's `Username` remains stable for the lifetime of the user.
 
-Relevant decisions::
+== Relevant decisions
+
 * xref:appuio-cloud:ROOT:explanation/decisions/usernames.adoc[User object names in the OpenShift cluster]
 
-Alternatives::
-* Disallow `Username` changes
-* Implement extra tooling to work around the limitations in OpenShift and allow `Username` changes.
+== Alternatives
 
-Decision::
-We disallow users to change their `Username` after creation of the user in {product}.
+. Disallow `Username` changes
+. Implement extra tooling to work around the limitations in OpenShift and allow `Username` changes.
 
-Rationale::
+== Decision
+
+Disallow `Username` changes
+
+== Rationale
 We decide to disallow users to change their `Username` after creation of the user in {product}.
 If a user needs to change their `Username`, they can register a new user with the desired `Username` and add the new user to the appropriate organizations.

--- a/docs/modules/ROOT/pages/explanation/decisions/usernames.adoc
+++ b/docs/modules/ROOT/pages/explanation/decisions/usernames.adoc
@@ -1,45 +1,41 @@
 = User object names in the OpenShift cluster
 
-Problem::
+== Problem
 We need to define an identifier which we use to name users which are synchronized from Keycloak to the OpenShift cluster.
-+
+
 The identifier should have the following properties:
-+
+
 * It should be stable for the lifetime of the user in Keycloak.
 * It must be suitable for use as an OpenShift resource name (namely for the OpenShift `User` resource)
 * It must be used to configure OpenShift `Group` membership when synchronizing groups from Keycloak.
 
-+
 In the implementation, this identifier is selected by providing an appropriate attribute name for the OpenID claim `preferred_username` in the OpenShift OpenID Connect identity provider configuration.
 Please note that regardless of the choice of identifier for `preferred_username`, the user's identity in the OpenShift cluster is always tied to their Keycloak user's `ID` property.
 This is because Openshift's OpenID Connect identity provider uses the OpenID claim `sub` to establish the user's identity, see the https://docs.openshift.com/container-platform/4.8/authentication/identity_providers/configuring-oidc-identity-provider.html[OpenShift documentation].
 The OpenID claim `sub` is mapped to the Keycloak user's `ID` by default.
 
+== Alternatives
 
-Alternatives::
-* Use the `Username` property of Keycloak user objects.
-+
+[qanda]
+Use the `Username` property of Keycloak user objects::
 With this approach, `oc whoami` shows users the `Username` they chose when registering their {product} user.
 However, Users can't change their `Username` after registration, as the OpenShift `User` and `Identity` objects (which are created when the users first logs in) aren't updated when users change their `Username` in Keycloak.
 
-* Use the `ID` property of Keycloak user objects.
-+
+Use the `ID` property of Keycloak user objects::
 With this approach, users can freely change their `Username` in Keycloak.
-+
 However, their `Username` doesn't appear anywhere in the OpenShift cluster with this approach and the output of `oc whoami` is the Keycloak user's `ID`.
 
-* Use the `Email` property of Keycloak user objects.
-+
+Use the `Email` property of Keycloak user objects::
 With this approach, users can't change their E-Mail address after signing up, for the same reasons as they can't change their `Username` property when using that property (see first alternative).
 
+== Decision
 
-Decision::
-We use the `Username` property of Keycloak user objects as the name for the resulting OpenShift `User` objects
+Use the `Username` property of Keycloak user objects
 
-Rationale::
+== Rationale
 
 For all described alternatives, Keycloak can be configured to require that the property must be unique per realm.
 Therefore, we don't risk having OpenShift `User` objects which are associated with multiple Keycloak users with any of the described alternatives.
-+
+
 We decide to use the `Username` property as the identifier used for the OpenShift `User` object.
 This choice provides the best trade-off in our eyes, as it allows users to change their E-Mail address at any time and it shows users a human-verifiable output when running `oc whoami`.


### PR DESCRIPTION
Introducing actual sections gives us more formatting and styling options.
The alternatives are using the `qanda` (read Q&A) modifier that numerates the entries and gives a formatted title. Looks quite nicely with current theme.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
