### PR TITLE
Update CPU/memory/storage quotas from recent calculations

### DIFF
--- a/docs/modules/ROOT/pages/references/quality-requirements/performance/resource-quota.adoc
+++ b/docs/modules/ROOT/pages/references/quality-requirements/performance/resource-quota.adoc
@@ -36,9 +36,16 @@ The workload is denied if they exceed one of the following Kubernetes resources:
 * Storage:
 ** Request: 50 GiB (total)
 ** PersistentVolumeClaims: 10
+** Ephemeral Storage (EmptyDir, writeable container layers)
+*** Requests: 250 MiB
+*** Limits: 500 MiB
 * ConfigMaps: 150
 * Secrets: 150
 * Services: 20
+* Pods: 45
+* ReplicationControllers: 100
+** LoadBalancers: 0
+** NodePorts: 0
 * Images
 ** ImageStream Tags: 50 (per ImageStream)
 ** ImageStreams: 20

--- a/docs/modules/ROOT/pages/references/quality-requirements/performance/resource-quota.adoc
+++ b/docs/modules/ROOT/pages/references/quality-requirements/performance/resource-quota.adoc
@@ -28,11 +28,11 @@ Workloads are the following Kubernetes resources:
 Response measure::
 The workload is denied if they exceed one of the following Kubernetes resources:
 * CPU (all containers in all Pods)
-** Requests: 2000m
-** Limits: 4000m
+** Requests: 1000m
+** Limits: 1500m
 * Memory (all containers in all Pods)
-** Requests: 3 GiB
-** Limits: 6 GiB
+** Requests: 4Gi
+** Limits: 4Gi
 * Storage:
 ** Request: 50 GiB (total)
 ** PersistentVolumeClaims: 10


### PR DESCRIPTION
> Looking at the current usage, around two thirds of the namespaces use 4GiB or less memory.
> This sounds like a reasonable quota to start with.
> For the compute resources, let's assume a node size of 32GB memory with 8 CPU cores (Plus-32 on Cloudscale and Huge on Exoscale).
> This results in 8 namespaces per node and therefore we can restrict the CPU requests to 1 core and the CPU limit to 1.5 cores.



<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
