### PR TITLE
Add dedicated tutorial label

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -6,6 +6,10 @@
             "labels": ["decision"]
         },
         {
+            "title": "## 📕 Tutorials",
+            "labels": ["tutorial"]
+        },
+        {
             "title": "## 🧾 Quality Requirements",
             "labels": ["requirement/quality"]
         },


### PR DESCRIPTION
I feel it's starting to make sense to better highlight how-tos and tutorial updates

Note: the label `tutorial` can be also applied for How-to pages, as they are kind of tutorials also, just very focused on specific topics.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
