### PR TITLE
Remove org prefix from OrganizationMembers

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
@@ -91,8 +91,8 @@ The filter uses the following heuristic:
 
 These are `ClusterRole` resources which are bound to a subject by a namespaced `RoleBinding`:
 
-`org-view`:: View (read only) access to an organization
-`org-admin`:: Admin (read / write) access to an organization
+`appuio-organization-viewer`:: View (read only) access to an organization
+`appuio-organization-admin`:: Admin (read / write) access to an organization
 
 By default, creating organizations can be done by all authenticated users.
 
@@ -106,7 +106,7 @@ All members of an organization are configured in an `OrganizationMembers` resour
 apiVersion: appuio.io/v1
 kind: OrganizationMembers
 metadata:
-  name: acme-corp-members
+  name: members
   namespace: org-acme-corp
 spec:
   userRefs: <1>


### PR DESCRIPTION
I suggest to:

* Name the cluster roles more specifc. My argument is to prevent ambiguity.
* Just name the OrganizationMembers object "members". As this is namespaced and a kind of its own, prefixing it with the organizaiton name is just verbose.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
