### PR TITLE
Rename Zone fields in Control API to match official naming convention

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/control-api-zone.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-zone.adoc
@@ -14,19 +14,19 @@ metadata:
 data:
   displayName: cloudscale.ch LPG 0
   features:
-    openshift-version: "4.8"
-    kubernetes-version: "1.21"
-    sdn: OVN-Kubernetes
+    openshiftVersion: "4.8"
+    kubernetesVersion: "1.21"
+    sdnPlugin: OVN-Kubernetes
   urls:
     console: https://console.cloudscale-lpg-0.appuio.cloud/
-    kubernetes-api: https://api.cloudscale-lpg-0.appuio.cloud:6443/
+    kubernetesAPI: https://api.cloudscale-lpg-0.appuio.cloud:6443/
     registry: https://registry.cloudscale-lpg-0.appuio.cloud
     logging: https://logging.cloudscale-lpg-0.appuio.cloud/
   cname: cname.cloudscale-lpg-0.appuio.cloud
-  default-app-domain: apps.cloudscale-lpg-0.appuio.cloud
-  gateway-ips:
+  defaultAppDomain: apps.cloudscale-lpg-0.appuio.cloud
+  gatewayIPs:
   - 185.98.123.122
-  cloud-provider:
+  cloudProvider:
     name: cloudscale.ch
     zones:
     - lpg1


### PR DESCRIPTION
According to [Kubernetes Naming convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions) this PR renames the field names to camelCase

See also relevant PR: https://github.com/appuio/control-api/pull/5

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
