### PR TITLE
Remove `org-` prefix for organization namespaces

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
@@ -19,19 +19,13 @@ apiVersion: appuio.io/v1
 kind: Organization
 metadata:
   name: acme-corp <1>
-  annotations:
-    organization.appuio.io/namespace: org-acme-corp <2>
 spec:
-  displayName: Acme Corp. <3>
+  displayName: Acme Corp. <2>
 ----
 Field mapping from the represented `Namespace` resource:
 
-<1> `metadata.labels[appuio.io/metadata.name]`
-<2> `metadata.name`
-<3> `metadata.annotations[organization.appuio.io/display-name]`
-
-An https://book.kubebuilder.io/reference/generating-crd.html#additional-printer-columns[additional printer column] can help to identify the associated namespace resource name.
-This is useful when working with organization-scoped objects which are available in the organization's namespace.
+<1> `metadata.name`
+<2> `metadata.annotations[organization.appuio.io/display-name]`
 
 .Original resource
 [source,yaml]
@@ -39,17 +33,14 @@ This is useful when working with organization-scoped objects which are available
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: org-acme-corp <1>
+  name: acme-corp
   labels:
-    appuio.io/resource.type: organization <2>
-    appuio.io/metadata.name: acme-corp <3>
+    appuio.io/resource.type: organization <1>
   annotations:
-    organization.appuio.io/display-name: Acme Corp. <4>
+    organization.appuio.io/display-name: Acme Corp. <2>
 ----
-<1> Resource name, prefixed with `org-` to circumvent possible name collision
-<2> Identify resource type, used by the API server to filter for namespaces representing organizations
-<3> `metadata.name` of the virtual `Organization` object
-<4> Reflected in the `Organization` object as `spec.displayName`
+<1> Identify resource type, used by the API server to filter for namespaces representing organizations
+<2> Reflected in the `Organization` object as `spec.displayName`
 
 == Labels and Annotations
 
@@ -64,11 +55,6 @@ metadata:
 |label
 |`v1/Namespace`
 |Identifies the resource type in the scope of the {controlapi}
-
-|`appuio.io/metadata.name`
-|label
-|`v1/Namespace`
-|`metadata.name` of the virtual resource
 
 |`organization.appuio.io/display-name`
 |annotation


### PR DESCRIPTION
There does not seem to be consensus on what naming collisions this prefix
should prevent.

The prefix makes the API less intuitive. When working with organization
`foo`, I expect to be able to access its teams in namespace `foo` and
not namespace `org-foo`. It's even worse when there actually is a
namespace `foo` and I get a permission denied error.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
