### PR TITLE
Add requirement that all user namespaces belong to an organization

### DIFF
--- a/docs/modules/ROOT/pages/references/quality-requirements/functional/namespace-organization.adoc
+++ b/docs/modules/ROOT/pages/references/quality-requirements/functional/namespace-organization.adoc
@@ -24,7 +24,7 @@ Rationale::
 All user namespaces must be associated with an organization for billing purposes.
 If users don't specify an explicit namespace by adding label `appuio.io/organization` on the namespace object, the namespace is created in their default organization.
 
-== Creating a namespace without an explicit organization label
+== Creating a Project
 
 Source::
 Developer

--- a/docs/modules/ROOT/pages/references/quality-requirements/functional/namespace-organization.adoc
+++ b/docs/modules/ROOT/pages/references/quality-requirements/functional/namespace-organization.adoc
@@ -1,0 +1,73 @@
+= User namespaces belong to an organization
+
+== Creating a namespace without an explicit organization label
+
+Source::
+Developer
+
+Stimulus::
+Creates a new namespace
+
+Environment::
+{zone}
+
+Artifact::
+kubectl
+
+Response::
+Namespace is created
+
+Response measure::
+Namespace belongs to the user's default organization
+
+Rationale::
+All user namespaces must be associated with an organization for billing purposes.
+If users don't specify an explicit namespace by adding label `appuio.io/organization` on the namespace object, the namespace is created in their default organization.
+
+== Creating a namespace without an explicit organization label
+
+Source::
+Developer
+
+Stimulus::
+Creates a new OpenShift project
+
+Environment::
+{zone}
+
+Artifact::
+oc / OpenShift web console
+
+Response::
+Project is created
+
+Response measure::
+Project (and its associated namespace) belongs to the user's default organization
+
+Rationale::
+All user namespaces must be associated with an organization for billing purposes.
+Since users don't have a way to specify an explicit organization when creating OpenShift projects, all namespaces created through OpenShift projects are associated with the user's default organization.
+
+== Creating a namespace with an explicit organization label
+
+Source::
+Developer
+
+Stimulus::
+Creates a new namespace with label `appuio.io/organization=purple-fox`
+
+Environment::
+{zone}
+
+Artifact::
+kubectl
+
+Response::
+Namespace is created if and only if the user is part of organization `purple-fox`
+
+Response measure::
+Namespace belongs to organization `purple-fox`
+
+Rationale::
+All user namespaces must be associated with an organization for billing purposes.
+Users are only allowed to create namespaces for organizations to which they belong

--- a/docs/modules/ROOT/partials/nav-reference.adoc
+++ b/docs/modules/ROOT/partials/nav-reference.adoc
@@ -29,6 +29,7 @@
 *** xref:appuio-cloud:ROOT:references/quality-requirements/functional/samplinginterval-for-invoicing.adoc[Sampling interval for invoicing]
 *** xref:appuio-cloud:ROOT:references/quality-requirements/functional/amplinginterval-for-collecti.adoc[Sampling interval for collecting metering data]
 *** xref:appuio-cloud:ROOT:references/quality-requirements/functional/samplinginterval-for-reportig.adoc[Sampling interval in the intermediate metering storage]
+*** xref:appuio-cloud:ROOT:references/quality-requirements/functional/namespace-organization.adoc[User namespaces belong to an organization]
 
 ** Performance
 *** xref:appuio-cloud:ROOT:references/quality-requirements/performance/ns-create-time.adoc[Time to create Namespace]


### PR DESCRIPTION
Will be linked in https://github.com/appuio/component-appuio-cloud/pull/63

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
