### PR TITLE
Use Keycloak username for Control API users instead of ID

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-org.adoc
@@ -151,18 +151,14 @@ metadata:
   namespace: org-acme-corp
 spec:
   userRefs: <1>
-  - id: bec0d928-2ae2-4cec-94a0-5f72f12b8b39
-  - username: peter.muster
+  - name: kate.demo
+  - name: peter.muster
 status:
   resolvedUserRefs: <2>
-  - id: bec0d928-2ae2-4cec-94a0-5f72f12b8b39
-    username: kate.demo
-  - id: 508a9160-977c-4c57-963f-c7b511c4ecc5
-    username: peter.muster
+  - name: kate.demo
+  - name: peter.muster
 ----
-<1> References to one or more xref:references/architecture/control-api-user.adoc[`User`] resource. +
-    Only one of the two parameters are allowed:
-
-    * `id` must match `metadata.name` of an existing `User` resource
-    * `username` must match `status.username` from an existing `User` resource
-<2> This is resolved by the xref:explanation/system/details-adapters.adoc[adapter]
+<1> References to one or more xref:references/architecture/control-api-user.adoc[`User`] resource. 
+    The `name` field must match `metadata.name` of an existing `User` resource.
+<2> This is resolved by the xref:explanation/system/details-adapters.adoc[adapter]. 
+    May only contain a subset of users if the adapter is unable to add some users.

--- a/docs/modules/ROOT/pages/references/architecture/control-api-team.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-team.adoc
@@ -15,19 +15,15 @@ metadata:
 spec:
   displayName: My Super Team 1
   userRefs: <2>
-  - id: bec0d928-2ae2-4cec-94a0-5f72f12b8b39
-  - username: peter.muster
+  - name: kate.demo
+  - name: peter.muster
 status:
   resolvedUserRefs: <3>
-  - id: bec0d928-2ae2-4cec-94a0-5f72f12b8b39
-    username: kate.demo
-  - id: 508a9160-977c-4c57-963f-c7b511c4ecc5
-    username: peter.muster
+  - name: kate.demo
+  - name: peter.muster
 ----
 <1> The organizations namespace
-<2> References to one or more xref:references/architecture/control-api-user.adoc[`User`] resource. +
-    Only one of the two parameters are allowed:
-
-    * `id` must match `metadata.name` of an existing `User` resource
-    * `username` must match `status.username` from an existing `User` resource
-<3> This resolved by the xref:explanation/system/details-adapters.adoc[adapter]
+<2> References to one or more xref:references/architecture/control-api-user.adoc[`User`] resource. 
+    The `name` field must match `metadata.name` of an existing `User` resource.
+<3> This is resolved by the xref:explanation/system/details-adapters.adoc[adapter]. 
+    May only contain a subset of users if the adapter is unable to add some users.

--- a/docs/modules/ROOT/pages/references/architecture/control-api-user.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-user.adoc
@@ -10,17 +10,18 @@ TIP: This resource implements the xref:references/functional-requirements/portal
 apiVersion: appuio.io/v1
 kind: User
 metadata:
-  name: bec0d928-2ae2-4cec-94a0-5f72f12b8b39 <1>
+  name: kate.demo <1>
 spec:
   preferences:
     defaultOrganizationRef: acme-corp
 status: <2>
+  id: bec0d928-2ae2-4cec-94a0-5f72f12b8b39
   displayName: Kate Demo
   username: kate.demo
   email: kate@demo.com
   defaultOrganizationRef: acme-corp
 ----
-<1> User ID in Keycloak
+<1> Username in Keycloak
 <2> Reflects actual configuration from adapter and exposes read-only fields
 
 == Access control
@@ -32,27 +33,27 @@ For each `User` object, a `ClusterRole` and `ClusterRoleBinding` is generated in
 ----
 kind: ClusterRole
 metadata:
-  name: bec0d928-2ae2-4cec-94a0-5f72f12b8b39-owner
+  name: kate.demo-owner
 rules:
   - apiGroups: ["appuio.io"]
     resources: ["users"]
-    resourceNames: ["bec0d928-2ae2-4cec-94a0-5f72f12b8b39"]
+    resourceNames: ["kate.demo"]
     verbs: ["get", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: bec0d928-2ae2-4cec-94a0-5f72f12b8b39-owner
+  name: kate.demo-owner
 subjects:
   - kind: User
-    name: appuio#bec0d928-2ae2-4cec-94a0-5f72f12b8b39 <1>
+    name: appuio#kate.demo <1>
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: bec0d928-2ae2-4cec-94a0-5f72f12b8b39-owner
+  name: kate.demo-owner
   apiGroup: rbac.authorization.k8s.io
 ----
 <1> This depends on the API server configuration: +
-    `oidc-username-claim=sub` and `oidc-username-prefix=appuio#`
+    `oidc-username-claim=preferred_username` and `oidc-username-prefix=appuio#`
 
 By default, only the subject which is the owner of the `User` object gets edit rights.


### PR DESCRIPTION
We decided not to use the Keycloak ID as an identifier for a Control API user. This removes the need for some translations and makes manual work with users more intuitive.

Implemented in https://github.com/appuio/control-api/pull/31
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
