### PR TITLE
Add instructions to global env to setup cloudscale metrics collector

### DIFF
--- a/docs/modules/ROOT/pages/how-to/vshn-example/activate-global.adoc
+++ b/docs/modules/ROOT/pages/how-to/vshn-example/activate-global.adoc
@@ -6,6 +6,8 @@ NOTE: This guide is targeted at VSHN employees.
 
 * working Commodore setup
 * SMTP server for sending out emails from Keycloak
+* Access to control.cloudscale.ch
+* `vault`
 
 == Configure Cluster
 
@@ -46,3 +48,25 @@ Client Roles = appuio-cloud-realm
 Assigned Roles = view-users
 ----
 <1> The tabs are visible after saving the new user first.
+
+== Configure Cloudscale Metrics Collector
+
+. Login to Vault.
++
+[source,bash]
+----
+export VAULT_ADDR=https://vault-prod.syn.vshn.net
+vault login -method=oidc
+----
+
+. Login to control.cloudscale.ch.
+
+. Create a new API token within the `VSHN AppCat objects-lpg-2` project, give it a memorable name like `cloudscale-metrics-collector` and read-only access.
+
+. Save the token in Vault.
++
+[source,bash]
+----
+parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cloudscale-metrics-collector"
+vault kv put "${parent}" token=<the-cloudscale-token>
+----


### PR DESCRIPTION
This PR adds instructions on how to save the cloudscale metrics collector, required for billing AppCat service "ObjectStorage".

See also:
* https://hub.syn.tools/cloudscale-metrics-collector/how-tos/installation.html
* https://github.com/vshn/cloudscale-metrics-collector/

## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
