### PR TITLE
Invitation: Switch from `REDEEM` custom method to virtual, create-only InvitationRedeemRequest

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/control-api-invitation.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/control-api-invitation.adoc
@@ -77,16 +77,19 @@ This is enforced by the API server and mitigates privilege escalation risks.
 
 Invitations can be accepted by any user in possession of the invitation token.
 
-Invitations are accepted by sending a `REDEEM` request to the `Invitation` resource.
+A virtual, create-only `InvitationRedeemRequest` resource exists to accept an invitation.
 
-[source,bash]
+[source,yaml]
 ----
-INVITATION=E303B166-5D66-4151-8F5F-B84BA84A7559 <1>
-TOKEN=BL30rELat6Faee5OgfmmZGhnECnp5H8GCbw7PcgRlTTXW0OAJMYl5anzuIdO
-
-curl -XREDEEM "$API/apis/user.appuio.io/v1/invitations/$INVITATION?token=$TOKEN"
+apiVersion: user.appuio.io/v1
+kind: InvitationRedeemRequest
+metadata:
+  name: E303B166-5D66-4151-8F5F-B84BA84A7559 <1>
+token: BL30rELat6Faee5OgfmmZGhnECnp5H8GCbw7PcgRlTTXW0OAJMYl5anzuIdO
 ----
 <1> Referencing the invitation resource above.
+
+The redeem request is successful if the server returns no error.
 
 == Invitation Messages
 


### PR DESCRIPTION
See https://github.com/appuio/control-api/issues/131

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
